### PR TITLE
Refactor `hcaptcha_tags` and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,25 +22,22 @@ Go to the [hCaptcha](https://hcaptcha.com/webmaster/signup) signup page to obtai
 
 The hostname you set it to must be a real hostname, since hCaptcha validates it when you create it in the portal. For example, `example.fmadata.com` does not have a DNS record, but `mydomain.com` does. The DNS record doesn't need to point to your application though, it just has to exist - that's why we added the record into the local hosts file.
 
-## Rails Installation
+## Installation
 
-```ruby
-gem "hcaptcha"
-```
-
-You can keep keys out of the code base with environment variables or with Rails [secrets](https://api.rubyonrails.org/classes/Rails/Application.html#method-i-secrets).
-
+FIrst, add the gem to your bundle:
 ```shell
-export HCAPTCHA_SITE_KEY='6Lc6BAAAAAAAAChqRbQZcn_yyyyyyyyyyyyyyyyy'
-export HCAPTCHA_SECRET_KEY='6Lc6BAAAAAAAAKN3DRm6VA_xxxxxxxxxxxxxxxxx'
+bundle add hcaptcha
 ```
 
+Then, set the following environment variables:
+* `HCAPTCHA_SECRET_KEY`
+* `HCAPTCHA_SITE_KEY`
 
-`include Hcaptcha::Adapters::ViewMethods` where you need `recaptcha_tags`
+> 💡 You should keep keys out of your codebase with external environment variables (using your shell's `export` command), Rails (< 5.2) [secrets](https://guides.rubyonrails.org/v5.1/security.html#custom-secrets), Rails (5.2+) [credentials](https://guides.rubyonrails.org/security.html#custom-credentials), the [dotenv](https://github.com/bkeepers/dotenv) or [figaro](https://github.com/laserlemon/figaro) gems, …
 
-`include Hcaptcha::Adapters::ControllerMethods` where you need `verify_recaptcha`
+## Usage
 
-Add `hcaptcha_tags` to the forms you want to protect:
+First, add `hcaptcha_tags` to the forms you want to protect:
 
 ```erb
 <%= form_for @foo do |f| %>
@@ -62,12 +59,51 @@ else
 end
 ```
 
+If you are **not using Rails**, you should:
+* `include Hcaptcha::Adapters::ViewMethods` where you need `recaptcha_tags`
+* `include Hcaptcha::Adapters::ControllerMethods` where you need `verify_hcaptcha`
 
-## hCaptcha API and Usage
+### API details
 
-### `hcaptcha_tags`
+### `hcaptcha_tags(options = {})`
 
 Use in your views to render the JavaScript widget.
+
+Available options:
+
+| Option                  | Description |
+|-------------------------|-------------|
+| `:badge`                | _legacy, ignored_
+| `:callback`             | _see [official documentation](https://docs.hcaptcha.com/configuration)_
+| `:chalexpired_callback` | _see [official documentation](https://docs.hcaptcha.com/configuration)_
+| `:class`                | Additional CSS classes added to `h-captcha` on the placeholder
+| `:close_callback`       | _see [official documentation](https://docs.hcaptcha.com/configuration)_
+| `:error_callback`       | _see [official documentation](https://docs.hcaptcha.com/configuration)_
+| `:expired_callback`     | _see [official documentation](https://docs.hcaptcha.com/configuration)_
+| `:external_script`      | _alias for `:script` option_
+| `:hl`                   | _see [official documentation](https://docs.hcaptcha.com/configuration) and [available language codes](https://docs.hcaptcha.com/languages)_
+| `:open_callback`        | _see [official documentation](https://docs.hcaptcha.com/configuration)_
+| `:nonce`                | Add a `nonce="…"` attribute to the `<script>` tag
+| `:onload`               | _see [official documentation](https://docs.hcaptcha.com/configuration)_
+| `:recaptchacompat`      | _see [official documentation](https://docs.hcaptcha.com/configuration)_
+| `:render`               | _see [official documentation](https://docs.hcaptcha.com/configuration)_
+| `:script_async`         | Add `async` attribute to the `<script>` tag (default: `true`)
+| `:script_defer`         | Add `defer` attribute to the `<script>` tag (default: `true`)
+| `:script`               | Generate the `<script>` tag (default: `true`)
+| `:site_key`             | Set hCaptcha Site Key (overrides `HCAPTCHA_SITE_KEY` environment variable)
+| `:size`                 | _see [official documentation](https://docs.hcaptcha.com/configuration)_
+| `:stoken`               | _legacy, raises an exception_
+| `:ssl`                  | _legacy, raises an exception_
+| `:theme`                | _see [official documentation](https://docs.hcaptcha.com/configuration)_ (default: `:dark`)
+| `:type`                 | _legacy, ignored_
+| `:ui`                   | _legacy, ignored_
+
+> ℹ️ Unkown options will be passed directly as attributes to the placeholder element.
+>
+> For example, `hcaptcha_tags(foo: "bar")` will generate the default script tag and the following placeholder tag:
+> ```html
+> <div class="h-captcha" data-sitekey="…" foo="bar"></div>
+> ```
 
 ### `verify_recaptcha`
 

--- a/lib/hcaptcha/helpers.rb
+++ b/lib/hcaptcha/helpers.rb
@@ -6,6 +6,9 @@ module Hcaptcha
       hcaptcha_unreachable: 'Oops, we failed to validate your hCaptcha response. Please try again.',
       verification_failed: 'hCaptcha verification failed, please try again.'
     }.freeze
+    DEFAULT_OPTIONS = {
+      theme: :dark
+    }.freeze
 
     def self.hcaptcha(options)
       if options.key?(:stoken)
@@ -13,6 +16,10 @@ module Hcaptcha
       end
       if options.key?(:ssl)
         raise(HcaptchaError, "SSL is now always true. Please remove 'ssl' from your calls to hcaptcha_tags.")
+      end
+
+      DEFAULT_OPTIONS.each do |name, value|
+        options[name] ||= value
       end
 
       html, tag_attributes = components(options)

--- a/lib/hcaptcha/helpers.rb
+++ b/lib/hcaptcha/helpers.rb
@@ -15,12 +15,8 @@ module Hcaptcha
         raise(HcaptchaError, "SSL is now always true. Please remove 'ssl' from your calls to hcaptcha_tags.")
       end
 
-      html, tag_attributes = components(options.dup)
+      html, tag_attributes = components(options)
       html << %(<div #{tag_attributes}></div>\n)
-
-      html << <<-HTML
-        <div class="h-captcha" data-sitekey="#{Hcaptcha.configuration.site_key!}" data-theme="dark"></div>
-      HTML
 
       html.respond_to?(:html_safe) ? html.html_safe : html
     end
@@ -80,7 +76,7 @@ module Hcaptcha
       attributes.merge! data_attributes
 
       # The remaining options will be added as attributes on the tag.
-      attributes["class"] = "hcaptcha #{class_attribute}"
+      attributes["class"] = "h-captcha #{class_attribute}"
       tag_attributes = attributes.merge(options).map { |k, v| %(#{k}="#{v}") }.join(" ")
 
       [html, tag_attributes]

--- a/test/client_helper_test.rb
+++ b/test/client_helper_test.rb
@@ -3,11 +3,23 @@ require_relative 'helper'
 describe 'View helpers' do
   include Hcaptcha::Adapters::ViewMethods
 
-  it "uses ssl" do
+  it "uses SSL" do
     hcaptcha_tags.must_include "\"#{Hcaptcha.configuration.api_server_url}\""
   end
 
-  it "can include size" do
+  it "can include `theme`" do
+    html = hcaptcha_tags(theme: "light")
+    html.must_include("data-theme=\"light\"")
+
+    html = hcaptcha_tags(theme: "dark")
+    html.wont_include("data-theme=\"light\"")
+    html.must_include("data-theme=\"dark\"")
+
+    html = hcaptcha_tags
+    html.must_include("data-theme=")
+  end
+
+  it "can include `size`" do
     html = hcaptcha_tags(size: 10)
     html.must_include("data-size=\"10\"")
   end
@@ -19,27 +31,30 @@ describe 'View helpers' do
     end
   end
 
-  it "includes id as div attribute" do
+  it "includes `id` as div attribute" do
     html = hcaptcha_tags(id: 'my_id')
     html.must_include(" id=\"my_id\"")
   end
 
-  it "translates tabindex attribute to data- attribute for hcaptcha_tags" do
+  it "translates `tabindex` attribute to data- attribute for hcaptcha_tags" do
     html = hcaptcha_tags(tabindex: 123)
     html.must_include(" data-tabindex=\"123\"")
   end
 
-  it "includes nonce attribute" do
+  it "includes `nonce` attribute" do
     html = hcaptcha_tags(nonce: 'P9Y0b6dLSkApYRdOULGW57XHcYNJJKeLwxA2az/Ka9s=')
     html.must_include(" nonce='P9Y0b6dLSkApYRdOULGW57XHcYNJJKeLwxA2az/Ka9s='")
   end
 
-  it "does not include <script> tag when setting script: false" do
+  it "does not include <script> tag when setting `script: false` or `external_script: false`" do
     html = hcaptcha_tags(script: false)
+    html.wont_include("<script")
+
+    html = hcaptcha_tags(external_script: false)
     html.wont_include("<script")
   end
 
-  it "adds :hl option to the url" do
+  it "adds :hl option to the URL" do
     html = hcaptcha_tags(hl: 'en')
     html.must_include("hl=en")
 
@@ -51,7 +66,7 @@ describe 'View helpers' do
     html.wont_include("hl=")
   end
 
-  it "adds :onload option to the url" do
+  it "adds `onload` option to the URL" do
     html = hcaptcha_tags(onload: 'foobar')
     html.must_include("onload=foobar")
 
@@ -63,7 +78,7 @@ describe 'View helpers' do
     html.wont_include("onload=")
   end
 
-  it "adds :render option to the url" do
+  it "adds `render` option to the URL" do
     html = hcaptcha_tags(render: 'onload')
     html.must_include("render=onload")
 
@@ -75,7 +90,19 @@ describe 'View helpers' do
     html.wont_include("render=")
   end
 
-  it "adds query params to the url" do
+  it "adds `recaptchacompat` option to the URL" do
+    html = hcaptcha_tags(recaptchacompat: "on")
+    html.must_include("recaptchacompat=on")
+
+    html = hcaptcha_tags(recaptchacompat: "off")
+    html.wont_include("recaptchacompat=on")
+    html.must_include("recaptchacompat=off")
+
+    html = hcaptcha_tags
+    html.wont_include("recaptchacompat=")
+  end
+
+  it "adds query params to the URL" do
     html = hcaptcha_tags(hl: 'en', onload: 'foobar')
     html.must_include("?")
     html.must_include("hl=en")
@@ -83,13 +110,33 @@ describe 'View helpers' do
     html.must_include("onload=foobar")
   end
 
-  it "dasherizes the expired_callback attribute name" do
+  it "dasherizes the `expired_callback` attribute name" do
     html = hcaptcha_tags(expired_callback: 'my_expired_callback')
     html.must_include(" data-expired-callback=\"my_expired_callback\"")
   end
 
-  it "dasherizes error_callback attribute name" do
+  it "dasherizes `error_callback` attribute name" do
     html = hcaptcha_tags(error_callback: 'my_error_callback')
     html.must_include(" data-error-callback=\"my_error_callback\"")
+  end
+
+  it "dasherizes the `chalexpired_callback` attribute name" do
+    html = hcaptcha_tags(chalexpired_callback: 'my_chalexpired_callback')
+    html.must_include(" data-chalexpired-callback=\"my_chalexpired_callback\"")
+  end
+
+  it "dasherizes the `open_callback` attribute name" do
+    html = hcaptcha_tags(open_callback: 'my_open_callback')
+    html.must_include(" data-open-callback=\"my_open_callback\"")
+  end
+
+  it "dasherizes the `close_callback` attribute name" do
+    html = hcaptcha_tags(close_callback: 'my_close_callback')
+    html.must_include(" data-close-callback=\"my_close_callback\"")
+  end
+
+  it "adds unexpected options as HTML attributes" do
+    html = hcaptcha_tags(unexpected_option: 'my_unexpected_option')
+    html.must_include(" unexpected_option=\"my_unexpected_option\"")
   end
 end


### PR DESCRIPTION
This PR does multiple things (it can be reviewed commit by commit):
* update documentation in README
* remove duplicate placeholder tag
* refactor `hcaptcha_tags` code to be more readable (hopefully :grimacing:)
* remove support for some deprecated or reCaptcha-related options for `hcaptcha_tags`
* add support for some new options to `hcaptcha_tags`
* add tests for both new and existing `hcaptcha_tags` options

What could be done, but was not to avoid bloating this PR more than it already is:
* update documentation for `verify_hcaptcha`
* remove support for reCaptcha-specific options to `verify_hcaptcha` (_e.g._ `hostname`)
