### PR TITLE
add alternative for using docker secrets

### DIFF
--- a/lib/hcaptcha/configuration.rb
+++ b/lib/hcaptcha/configuration.rb
@@ -43,8 +43,8 @@ module Hcaptcha
       @skip_verify_env = %w[test cucumber]
       @handle_timeouts_gracefully = true
 
-      @secret_key = ENV['HCAPTCHA_SECRET_KEY']
-      @site_key = ENV['HCAPTCHA_SITE_KEY']
+      @secret_key = ENV['HCAPTCHA_SECRET_KEY'] || File.read("/run/secrets/hcaptcha_secret_key")
+      @site_key = ENV['HCAPTCHA_SITE_KEY'] || File.read("/run/secrets/hcaptcha_site_key")
       @verify_url = nil
       @api_server_url = nil
     end


### PR DESCRIPTION
If the application is deployed with docker and secret key and site key are stored with in docker secrets, it would be tedious to load them into the env and then read from env again. By this patch, we can read the keys from docker secrets directly, WITHOUT affecting existing users.