### PR TITLE
Themes instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,10 @@ By default, hCaptcha is skipped in "test" and "cucumber" env. To enable it durin
 ```ruby
 Hcaptcha.configuration.skip_verify_env.delete("test")
 ```
+
+## Themes
+
+By default, this plugin uses the dark theme for the hCaptcha widget. To change the theme used for rendering, you can use the following code:
+
+```ruby
+hcaptcha_tags(data-theme: "light")


### PR DESCRIPTION
I am reaching out on behalf of hCaptcha Support. Recently, we have received several cases from developers where altering the default dark theme was unclear, and there wasn't sufficient information on how to achieve this using the plugin.

We humbly propose adding the following instructions to the Readme.md file, covering the topic of how to change the default dark theme used by the plugin to the light theme.
